### PR TITLE
chore: creditsafe syna errors

### DIFF
--- a/__tests__/setup.js
+++ b/__tests__/setup.js
@@ -1,0 +1,9 @@
+global.console = {
+  error: jest.fn(), // console.error are ignored in tests
+
+  // Keep native behaviour for other methods, use those to print out things in your own tests, not `console.error`
+  log: console.log,
+  warn: console.warn,
+  info: console.info,
+  debug: console.debug,
+}

--- a/jest.config.js
+++ b/jest.config.js
@@ -13,6 +13,7 @@ module.exports = {
     prefix: '<rootDir>/',
   }),
   preset: 'ts-jest',
+  setupFilesAfterEnv: ['<rootDir>/__tests__/setup.js'],
   testEnvironment: 'node',
   testMatch: ['**/__tests__/**/*.ts', '**/?(*.)+(spec|test).ts'],
   watchPlugins: [

--- a/migrations/20210414155446_population_registration_sync_exceptions.js
+++ b/migrations/20210414155446_population_registration_sync_exceptions.js
@@ -1,0 +1,25 @@
+exports.up = (knex) => {
+  return knex.raw('create extension if not exists "uuid-ossp"').then(() =>
+    knex.schema.createTable(
+      'population_registration_sync_exceptions',
+      (table) => {
+        table
+          .uuid('id')
+          .primary()
+          .notNullable()
+          .defaultTo(knex.raw('uuid_generate_v4()'))
+
+        table.uuid('selection_id').notNullable()
+        table.uuid('contract_id').notNullable()
+        table.foreign('selection_id').references('selections.id')
+        table.string('note')
+      }
+    )
+  )
+}
+
+exports.down = (knex) => {
+  return knex.schema.dropTableIfExists(
+    'population_registration_sync_exceptions'
+  )
+}

--- a/src/adapters/creditsafe/__tests__/index.spec.ts
+++ b/src/adapters/creditsafe/__tests__/index.spec.ts
@@ -1,6 +1,5 @@
 import { getInformation } from '../index'
 import { createClientAsync } from 'soap'
-import config from '@app/config'
 
 jest.mock('soap')
 jest.mock('@app/config', () => ({
@@ -12,21 +11,95 @@ jest.mock('@app/config', () => ({
 }))
 
 describe('#Creditsafe', () => {
+  let creditSafeReply: any
+  let creditSafeError: any
+  let creditSafe: any
+  let pnrs: string[]
+
   beforeEach(() => {
-    jest.resetAllMocks()
-    ;(createClientAsync as jest.Mock).mockResolvedValue({
-      GetData: {
-        GetDataSoap: {
-          GetDataBySecure: jest.fn(),
+    pnrs = ['1212121212']
+    creditSafeReply = {
+      GetDataBySecureResult: {
+        Parameters: {
+          diffgram: {
+            NewDataSet: {
+              GETDATA_RESPONSE: [],
+            },
+          },
         },
       },
-    })
+    }
+
+    creditSafeError = null
+
+    creditSafe = {
+      GetData: {
+        GetDataSoap: {
+          GetDataBySecure: (_: any, callback: any) =>
+            callback(creditSafeError, creditSafeReply),
+        },
+      },
+    }
+    jest.resetAllMocks()
+    ;(createClientAsync as jest.Mock).mockResolvedValue(creditSafe)
   })
 
   describe('#getInformation', () => {
     test('it calls with formated personal numbers', () => {
       getInformation(['19121212-1212', '1212121212'])
       expect(createClientAsync).toHaveBeenCalledTimes(2)
+    })
+
+    test('it includes an exception for Avliden person', async () => {
+      creditSafeReply = {
+        GetDataBySecureResult: {
+          Error: {
+            Cause_of_Reject: 'S4',
+            Reject_text: 'Avliden',
+          },
+        },
+      }
+      const [{ pnr, exception }] = await getInformation(pnrs)
+      expect(pnr).toBe(pnrs[0])
+      expect(exception).toBe('Avliden')
+    })
+    test('it includes an exception Utvandrad person', async () => {
+      creditSafeReply = {
+        GetDataBySecureResult: {
+          Error: {
+            Cause_of_Reject: 'S6',
+            Reject_text: 'Utvandrad',
+          },
+        },
+      }
+      const [{ pnr, exception }] = await getInformation(pnrs)
+      expect(pnr).toBe(pnrs[0])
+      expect(exception).toBe('Utvandrad')
+    })
+    test('it includes an exception Skyddad personuppgift person', async () => {
+      creditSafeReply = {
+        GetDataBySecureResult: {
+          Error: {
+            Cause_of_Reject: 'S2',
+            Reject_text: 'Skyddad',
+          },
+        },
+      }
+      const [{ pnr, exception }] = await getInformation(pnrs)
+      expect(pnr).toBe(pnrs[0])
+      expect(exception).toBe('Skyddad')
+    })
+    test('it includes an exception whatever the Error reject text was', async () => {
+      creditSafeReply = {
+        GetDataBySecureResult: {
+          Error: {
+            Reject_text: 'It b0rked',
+          },
+        },
+      }
+      const [{ pnr, exception }] = await getInformation(pnrs)
+      expect(pnr).toBe(pnrs[0])
+      expect(exception).toBe('It b0rked')
     })
   })
 })

--- a/src/adapters/creditsafe/index.ts
+++ b/src/adapters/creditsafe/index.ts
@@ -19,11 +19,9 @@ const creditsafeXML = (pnr: string) => dedent`
 </GetDataBySecure>
 `
 
-let count = 0
-
 const getAddress = async (
   pnr: string
-): Promise<PopulationRegistrationInformation | null> => {
+): Promise<PopulationRegistrationInformation> => {
   const client = await createClientAsync(
     `${config.creditsafe.host}${config.creditsafe.getDataPath}`
   )
@@ -37,10 +35,14 @@ const getAddress = async (
         if (err) {
           return reject(err)
         }
+
         if (res.GetDataBySecureResult.Error) {
           console.error(res.GetDataBySecureResult.Error)
           // Not the prettiest, but rejecting will fail the entire Promise.all in getInformation
-          return resolve(null)
+          return resolve({
+            pnr,
+            exception: res.GetDataBySecureResult.Error.Reject_text,
+          })
         }
 
         const data =
@@ -51,6 +53,7 @@ const getAddress = async (
           pnr,
           name: `${data.FIRST_NAME} ${data.LAST_NAME}`,
           address: `${data.ADDRESS}`,
+          exception: null,
         })
       }
     )

--- a/src/adapters/syna/__tests__/index.spec.ts
+++ b/src/adapters/syna/__tests__/index.spec.ts
@@ -1,5 +1,6 @@
-import { getSynaBatches } from '../index'
+import { getSynaBatches, getInformation } from '../index'
 import { getSynaInformation } from '../syna'
+import * as synRaplies from './synaReplies.json'
 
 jest.mock('../syna')
 
@@ -97,5 +98,126 @@ describe('#getSynaBatches', () => {
 
     expect(result).toEqual(Array(5).fill(Omfragad))
     expect(getSynaInformation).toHaveBeenCalledTimes(3)
+  })
+})
+
+describe('#getInformation()', () => {
+  beforeEach(() => {
+    jest.resetAllMocks()
+  })
+  test('it works for real person', async () => {
+    ;(getSynaInformation as jest.Mock).mockResolvedValue(
+      synRaplies['Real Person']
+    )
+    const result = await getInformation(['8507099805'])
+    expect(result).toEqual([
+      {
+        address: 'Sveavägen 12',
+        name: 'LastName, FirstName',
+        pnr: '8507099805',
+      },
+    ])
+  })
+  test('it works for Avliden person', async () => {
+    ;(getSynaInformation as jest.Mock).mockResolvedValue(synRaplies['Avliden'])
+    const result = await getInformation(['8507099805'])
+    expect(result).toEqual([
+      {
+        address: 'Sveavägen 12',
+        name: 'LastName, FirstName',
+        pnr: '8507099805',
+      },
+    ])
+  })
+  test('it works for Särskild postadress utländsk person', async () => {
+    ;(getSynaInformation as jest.Mock).mockResolvedValue(
+      synRaplies['Särskild postadress utländsk']
+    )
+    const result = await getInformation(['8507099805'])
+    expect(result).toEqual([
+      {
+        address: 'Sveavägen 12',
+        name: 'LastName, FirstName',
+        pnr: '8507099805',
+      },
+    ])
+  })
+  test('it works for Folkbokföringsadress saknas person', async () => {
+    ;(getSynaInformation as jest.Mock).mockResolvedValue(
+      synRaplies['Folkbokföringsadress saknas']
+    )
+    const result = await getInformation(['8507099805'])
+    expect(result).toEqual([
+      {
+        address: 'Sveavägen 12',
+        name: 'LastName, FirstName',
+        pnr: '8507099805',
+      },
+    ])
+  })
+  test('it works for Utvandrad person', async () => {
+    ;(getSynaInformation as jest.Mock).mockResolvedValue(
+      synRaplies['Utvandrad']
+    )
+    const result = await getInformation(['8507099805'])
+    expect(result).toEqual([
+      {
+        address: 'Sveavägen 12',
+        name: 'LastName, FirstName',
+        pnr: '8507099805',
+      },
+    ])
+  })
+  test('it works for Skyddad personuppgift person', async () => {
+    ;(getSynaInformation as jest.Mock).mockResolvedValue(
+      synRaplies['Skyddad personuppgift']
+    )
+    const result = await getInformation(['8507099805'])
+    expect(result).toEqual([
+      {
+        address: 'Sveavägen 12',
+        name: 'LastName, FirstName',
+        pnr: '8507099805',
+      },
+    ])
+  })
+  test('it works for Personnummerbyte (nytt nummer) person', async () => {
+    ;(getSynaInformation as jest.Mock).mockResolvedValue(
+      synRaplies['Personnummerbyte (nytt nummer)']
+    )
+    const result = await getInformation(['8507099805'])
+    expect(result).toEqual([
+      {
+        address: 'Sveavägen 12',
+        name: 'LastName, FirstName',
+        pnr: '8507099805',
+      },
+    ])
+  })
+  test('it works for Personnummerbyte(gammalt nummer) person', async () => {
+    ;(getSynaInformation as jest.Mock).mockResolvedValue(
+      synRaplies['Personnummerbyte(gammalt nummer)']
+    )
+    const result = await getInformation(['8507099805'])
+    expect(result).toEqual([
+      {
+        address: 'Sveavägen 12',
+        name: 'LastName, FirstName',
+        pnr: '8507099805',
+      },
+    ])
+  })
+  test('it works for Särskild postadress svensk person', async () => {
+    ;(getSynaInformation as jest.Mock).mockResolvedValue(
+      synRaplies['Särskild postadress svensk']
+    )
+    const result = await getInformation(['8507099805'])
+    expect(result).toEqual([
+      {
+        address: 'Sveavägen 12',
+        name: 'LastName, FirstName',
+        pnr: '8507099805',
+      },
+    ])
   })
 })

--- a/src/adapters/syna/__tests__/index.spec.ts
+++ b/src/adapters/syna/__tests__/index.spec.ts
@@ -1,8 +1,11 @@
 import { getSynaBatches, getInformation } from '../index'
 import { getSynaInformation } from '../syna'
-import * as synRaplies from './synaReplies.json'
+import * as synaReplies from './synaReplies.json'
 
 jest.mock('../syna')
+jest.mock('@app/helpers/personnummer', () => ({
+  format: (args: any) => args,
+}))
 
 const empty = {
   kod: '',
@@ -105,119 +108,65 @@ describe('#getInformation()', () => {
   beforeEach(() => {
     jest.resetAllMocks()
   })
-  test('it works for real person', async () => {
+  test('it has no exception for functioning person', async () => {
     ;(getSynaInformation as jest.Mock).mockResolvedValue(
-      synRaplies['Real Person']
+      synaReplies['Real Person']
     )
-    const result = await getInformation(['8507099805'])
-    expect(result).toEqual([
-      {
-        address: 'Sveavägen 12',
-        name: 'LastName, FirstName',
-        pnr: '8507099805',
-      },
-    ])
+    const [{ exception }] = await getInformation(['8507099805'])
+    expect(exception).toBeNull()
   })
-  test('it works for Avliden person', async () => {
-    ;(getSynaInformation as jest.Mock).mockResolvedValue(synRaplies['Avliden'])
-    const result = await getInformation(['8507099805'])
-    expect(result).toEqual([
-      {
-        address: 'Sveavägen 12',
-        name: 'LastName, FirstName',
-        pnr: '8507099805',
-      },
-    ])
+  test('it includes an exception for Avliden person', async () => {
+    ;(getSynaInformation as jest.Mock).mockResolvedValue(synaReplies['Avliden'])
+    const [{ exception }] = await getInformation(['8507099805'])
+    expect(exception).toBe('Personen är avliden 2017-04-12')
   })
-  test('it works for Särskild postadress utländsk person', async () => {
+  test('it includes an exception Särskild postadress utländsk person', async () => {
     ;(getSynaInformation as jest.Mock).mockResolvedValue(
-      synRaplies['Särskild postadress utländsk']
+      synaReplies['Särskild postadress utländsk']
     )
-    const result = await getInformation(['8507099805'])
-    expect(result).toEqual([
-      {
-        address: 'Sveavägen 12',
-        name: 'LastName, FirstName',
-        pnr: '8507099805',
-      },
-    ])
+    const [{ exception }] = await getInformation(['8507099805'])
+    expect(exception).toBe('Särskild postadress utländsk')
   })
-  test('it works for Folkbokföringsadress saknas person', async () => {
+  test('it includes an exception Folkbokföringsadress saknas person', async () => {
     ;(getSynaInformation as jest.Mock).mockResolvedValue(
-      synRaplies['Folkbokföringsadress saknas']
+      synaReplies['Folkbokföringsadress saknas']
     )
-    const result = await getInformation(['8507099805'])
-    expect(result).toEqual([
-      {
-        address: 'Sveavägen 12',
-        name: 'LastName, FirstName',
-        pnr: '8507099805',
-      },
-    ])
+    const [{ exception }] = await getInformation(['8507099805'])
+    expect(exception).toBe('Folkbokföringsadress saknas')
   })
-  test('it works for Utvandrad person', async () => {
+  test('it includes an exception Utvandrad person', async () => {
     ;(getSynaInformation as jest.Mock).mockResolvedValue(
-      synRaplies['Utvandrad']
+      synaReplies['Utvandrad']
     )
-    const result = await getInformation(['8507099805'])
-    expect(result).toEqual([
-      {
-        address: 'Sveavägen 12',
-        name: 'LastName, FirstName',
-        pnr: '8507099805',
-      },
-    ])
+    const [{ exception }] = await getInformation(['8507099805'])
+    expect(exception).toBe('Utvandrad eller avregistrerad av annat skäl')
   })
-  test('it works for Skyddad personuppgift person', async () => {
+  test('it includes an exception Skyddad personuppgift person', async () => {
     ;(getSynaInformation as jest.Mock).mockResolvedValue(
-      synRaplies['Skyddad personuppgift']
+      synaReplies['Skyddad personuppgift']
     )
-    const result = await getInformation(['8507099805'])
-    expect(result).toEqual([
-      {
-        address: 'Sveavägen 12',
-        name: 'LastName, FirstName',
-        pnr: '8507099805',
-      },
-    ])
+    const [{ exception }] = await getInformation(['8507099805'])
+    expect(exception).toBe('Personen har skyddade personuppgifter')
   })
-  test('it works for Personnummerbyte (nytt nummer) person', async () => {
+  test('it includes an exception Personnummerbyte (nytt nummer) person', async () => {
     ;(getSynaInformation as jest.Mock).mockResolvedValue(
-      synRaplies['Personnummerbyte (nytt nummer)']
+      synaReplies['Personnummerbyte (nytt nummer)']
     )
-    const result = await getInformation(['8507099805'])
-    expect(result).toEqual([
-      {
-        address: 'Sveavägen 12',
-        name: 'LastName, FirstName',
-        pnr: '8507099805',
-      },
-    ])
+    const [{ exception }] = await getInformation(['8507099805'])
+    expect(exception).toBe('Personnummerbyte. Gammalt nummer: 920230-2320')
   })
-  test('it works for Personnummerbyte(gammalt nummer) person', async () => {
+  test('it includes an exception Personnummerbyte(gammalt nummer) person', async () => {
     ;(getSynaInformation as jest.Mock).mockResolvedValue(
-      synRaplies['Personnummerbyte(gammalt nummer)']
+      synaReplies['Personnummerbyte(gammalt nummer)']
     )
-    const result = await getInformation(['8507099805'])
-    expect(result).toEqual([
-      {
-        address: 'Sveavägen 12',
-        name: 'LastName, FirstName',
-        pnr: '8507099805',
-      },
-    ])
+    const [{ exception }] = await getInformation(['8507099805'])
+    expect(exception).toBe('Personnummerbyte. Gammalt nummer: 920230-2320')
   })
-  test('it works for Särskild postadress svensk person', async () => {
+  test('it includes an exception Särskild postadress svensk person', async () => {
     ;(getSynaInformation as jest.Mock).mockResolvedValue(
-      synRaplies['Särskild postadress svensk']
+      synaReplies['Särskild postadress svensk']
     )
-    const result = await getInformation(['8507099805'])
-    expect(result).toEqual([
-      {
-        address: 'Sveavägen 12',
-        name: 'LastName, FirstName',
-        pnr: '8507099805',
-      },
-    ])
+    const [{ exception }] = await getInformation(['8507099805'])
+    expect(exception).toBe('Särskild postadress svensk')
   })
 })

--- a/src/adapters/syna/__tests__/index.spec.ts
+++ b/src/adapters/syna/__tests__/index.spec.ts
@@ -62,111 +62,115 @@ const generateSynaResponse = (numberOfPersons: number): syna.RootObject => {
   return root
 }
 
-describe('#getSynaBatches', () => {
-  beforeEach(() => {
-    jest.resetAllMocks()
+describe('#Syna', () => {
+  describe('#getSynaBatches', () => {
+    beforeEach(() => {
+      jest.resetAllMocks()
+    })
+
+    test('it gets one batch when the number of pnrs are less than batch size', async () => {
+      const root = generateSynaResponse(1)
+      ;(getSynaInformation as jest.Mock).mockResolvedValue(root)
+
+      const result = await getSynaBatches(['pnr'], 10)
+      expect(result).toEqual([Omfragad])
+      expect(getSynaInformation).toHaveBeenCalledTimes(1)
+      expect(getSynaInformation).toHaveBeenCalledWith(['pnr'])
+    })
+
+    test('it gets multiple batches when the number of pnrs are bigger than batch size', async () => {
+      const root = generateSynaResponse(2)
+      ;(getSynaInformation as jest.Mock).mockResolvedValue(root)
+
+      const pnrs = Array(10).fill('pnr')
+      const result = await getSynaBatches(pnrs, 2)
+
+      expect(result).toEqual(Array(10).fill(Omfragad))
+      expect(getSynaInformation).toHaveBeenCalledTimes(5)
+    })
+
+    test('it gets correct number of batches when not devidable', async () => {
+      const rootLastCall = generateSynaResponse(1)
+      const root2 = generateSynaResponse(2)
+      ;(getSynaInformation as jest.Mock)
+        .mockResolvedValueOnce(root2)
+        .mockResolvedValueOnce(root2)
+        .mockResolvedValueOnce(rootLastCall)
+
+      const pnrs = Array(5).fill('pnr')
+      const result = await getSynaBatches(pnrs, 2)
+
+      expect(result).toEqual(Array(5).fill(Omfragad))
+      expect(getSynaInformation).toHaveBeenCalledTimes(3)
+    })
   })
 
-  test('it gets one batch when the number of pnrs are less than batch size', async () => {
-    const root = generateSynaResponse(1)
-    ;(getSynaInformation as jest.Mock).mockResolvedValue(root)
-
-    const result = await getSynaBatches(['pnr'], 10)
-    expect(result).toEqual([Omfragad])
-    expect(getSynaInformation).toHaveBeenCalledTimes(1)
-    expect(getSynaInformation).toHaveBeenCalledWith(['pnr'])
-  })
-
-  test('it gets multiple batches when the number of pnrs are bigger than batch size', async () => {
-    const root = generateSynaResponse(2)
-    ;(getSynaInformation as jest.Mock).mockResolvedValue(root)
-
-    const pnrs = Array(10).fill('pnr')
-    const result = await getSynaBatches(pnrs, 2)
-
-    expect(result).toEqual(Array(10).fill(Omfragad))
-    expect(getSynaInformation).toHaveBeenCalledTimes(5)
-  })
-
-  test('it gets correct number of batches when not devidable', async () => {
-    const rootLastCall = generateSynaResponse(1)
-    const root2 = generateSynaResponse(2)
-    ;(getSynaInformation as jest.Mock)
-      .mockResolvedValueOnce(root2)
-      .mockResolvedValueOnce(root2)
-      .mockResolvedValueOnce(rootLastCall)
-
-    const pnrs = Array(5).fill('pnr')
-    const result = await getSynaBatches(pnrs, 2)
-
-    expect(result).toEqual(Array(5).fill(Omfragad))
-    expect(getSynaInformation).toHaveBeenCalledTimes(3)
-  })
-})
-
-describe('#getInformation()', () => {
-  beforeEach(() => {
-    jest.resetAllMocks()
-  })
-  test('it has no exception for functioning person', async () => {
-    ;(getSynaInformation as jest.Mock).mockResolvedValue(
-      synaReplies['Real Person']
-    )
-    const [{ exception }] = await getInformation(['8507099805'])
-    expect(exception).toBeNull()
-  })
-  test('it includes an exception for Avliden person', async () => {
-    ;(getSynaInformation as jest.Mock).mockResolvedValue(synaReplies['Avliden'])
-    const [{ exception }] = await getInformation(['8507099805'])
-    expect(exception).toBe('Personen är avliden 2017-04-12')
-  })
-  test('it includes an exception Särskild postadress utländsk person', async () => {
-    ;(getSynaInformation as jest.Mock).mockResolvedValue(
-      synaReplies['Särskild postadress utländsk']
-    )
-    const [{ exception }] = await getInformation(['8507099805'])
-    expect(exception).toBe('Särskild postadress utländsk')
-  })
-  test('it includes an exception Folkbokföringsadress saknas person', async () => {
-    ;(getSynaInformation as jest.Mock).mockResolvedValue(
-      synaReplies['Folkbokföringsadress saknas']
-    )
-    const [{ exception }] = await getInformation(['8507099805'])
-    expect(exception).toBe('Folkbokföringsadress saknas')
-  })
-  test('it includes an exception Utvandrad person', async () => {
-    ;(getSynaInformation as jest.Mock).mockResolvedValue(
-      synaReplies['Utvandrad']
-    )
-    const [{ exception }] = await getInformation(['8507099805'])
-    expect(exception).toBe('Utvandrad eller avregistrerad av annat skäl')
-  })
-  test('it includes an exception Skyddad personuppgift person', async () => {
-    ;(getSynaInformation as jest.Mock).mockResolvedValue(
-      synaReplies['Skyddad personuppgift']
-    )
-    const [{ exception }] = await getInformation(['8507099805'])
-    expect(exception).toBe('Personen har skyddade personuppgifter')
-  })
-  test('it includes an exception Personnummerbyte (nytt nummer) person', async () => {
-    ;(getSynaInformation as jest.Mock).mockResolvedValue(
-      synaReplies['Personnummerbyte (nytt nummer)']
-    )
-    const [{ exception }] = await getInformation(['8507099805'])
-    expect(exception).toBe('Personnummerbyte. Gammalt nummer: 920230-2320')
-  })
-  test('it includes an exception Personnummerbyte(gammalt nummer) person', async () => {
-    ;(getSynaInformation as jest.Mock).mockResolvedValue(
-      synaReplies['Personnummerbyte(gammalt nummer)']
-    )
-    const [{ exception }] = await getInformation(['8507099805'])
-    expect(exception).toBe('Personnummerbyte. Gammalt nummer: 920230-2320')
-  })
-  test('it includes an exception Särskild postadress svensk person', async () => {
-    ;(getSynaInformation as jest.Mock).mockResolvedValue(
-      synaReplies['Särskild postadress svensk']
-    )
-    const [{ exception }] = await getInformation(['8507099805'])
-    expect(exception).toBe('Särskild postadress svensk')
+  describe('#getInformation()', () => {
+    beforeEach(() => {
+      jest.resetAllMocks()
+    })
+    test('it has no exception for functioning person', async () => {
+      ;(getSynaInformation as jest.Mock).mockResolvedValue(
+        synaReplies['Real Person']
+      )
+      const [{ exception }] = await getInformation(['8507099805'])
+      expect(exception).toBeNull()
+    })
+    test('it includes an exception for Avliden person', async () => {
+      ;(getSynaInformation as jest.Mock).mockResolvedValue(
+        synaReplies['Avliden']
+      )
+      const [{ exception }] = await getInformation(['8507099805'])
+      expect(exception).toBe('Personen är avliden 2017-04-12')
+    })
+    test('it includes an exception Särskild postadress utländsk person', async () => {
+      ;(getSynaInformation as jest.Mock).mockResolvedValue(
+        synaReplies['Särskild postadress utländsk']
+      )
+      const [{ exception }] = await getInformation(['8507099805'])
+      expect(exception).toBe('Särskild postadress utländsk')
+    })
+    test('it includes an exception Folkbokföringsadress saknas person', async () => {
+      ;(getSynaInformation as jest.Mock).mockResolvedValue(
+        synaReplies['Folkbokföringsadress saknas']
+      )
+      const [{ exception }] = await getInformation(['8507099805'])
+      expect(exception).toBe('Folkbokföringsadress saknas')
+    })
+    test('it includes an exception Utvandrad person', async () => {
+      ;(getSynaInformation as jest.Mock).mockResolvedValue(
+        synaReplies['Utvandrad']
+      )
+      const [{ exception }] = await getInformation(['8507099805'])
+      expect(exception).toBe('Utvandrad eller avregistrerad av annat skäl')
+    })
+    test('it includes an exception Skyddad personuppgift person', async () => {
+      ;(getSynaInformation as jest.Mock).mockResolvedValue(
+        synaReplies['Skyddad personuppgift']
+      )
+      const [{ exception }] = await getInformation(['8507099805'])
+      expect(exception).toBe('Personen har skyddade personuppgifter')
+    })
+    test('it includes an exception Personnummerbyte (nytt nummer) person', async () => {
+      ;(getSynaInformation as jest.Mock).mockResolvedValue(
+        synaReplies['Personnummerbyte (nytt nummer)']
+      )
+      const [{ exception }] = await getInformation(['8507099805'])
+      expect(exception).toBe('Personnummerbyte. Gammalt nummer: 920230-2320')
+    })
+    test('it includes an exception Personnummerbyte(gammalt nummer) person', async () => {
+      ;(getSynaInformation as jest.Mock).mockResolvedValue(
+        synaReplies['Personnummerbyte(gammalt nummer)']
+      )
+      const [{ exception }] = await getInformation(['8507099805'])
+      expect(exception).toBe('Personnummerbyte. Gammalt nummer: 920230-2320')
+    })
+    test('it includes an exception Särskild postadress svensk person', async () => {
+      ;(getSynaInformation as jest.Mock).mockResolvedValue(
+        synaReplies['Särskild postadress svensk']
+      )
+      const [{ exception }] = await getInformation(['8507099805'])
+      expect(exception).toBe('Särskild postadress svensk')
+    })
   })
 })

--- a/src/adapters/syna/__tests__/synaReplies.json
+++ b/src/adapters/syna/__tests__/synaReplies.json
@@ -1,0 +1,622 @@
+{
+  "Avliden": {
+    "Svar": {
+      "ec": "OK",
+      "Produkt": {
+        "id": "BFbokf",
+        "ver": "1.4"
+      },
+      "Process": {
+        "prddebug": "0",
+        "debug": "0",
+        "trace": "1"
+      },
+      "Objektlista": {
+        "antal": "1",
+        "Objekt": [
+          {
+            "Omfragad": {
+              "id": "2202302226",
+              "sekel": "19",
+              "not": "Personen är avliden 2017-04-12",
+              "Namnlista": {
+                "Namn": {
+                  "tilltal": "",
+                  "_t": "Hjalmarsson, Gudrun Helga"
+                },
+                "Mellannamn": "Helga",
+                "Efternamn": "Hjalmarsson",
+                "Fornamn": "Gudrun"
+              },
+              "Adresslista": {
+                "Adress": [
+                  {
+                    "typ": "fbf",
+                    "not": "Senast kända folkbokföringsuppgifter:",
+                    "Gatabox": "Härnerudsgatan 9",
+                    "Postnr": "22525",
+                    "Postort": "Vaggeryd",
+                    "Lan": {
+                      "kod": "06",
+                      "_t": "Jönköpings län"
+                    },
+                    "Kommun": {
+                      "kod": "65",
+                      "_t": "Vaggeryd"
+                    },
+                    "Forsamling": {
+                      "kod": "01",
+                      "_t": "Byarum-Bondstorp"
+                    },
+                    "Landsdel": {
+                      "kod": ""
+                    },
+                    "Landskap": {
+                      "kod": ""
+                    },
+                    "Distrikt": {
+                      "kod": ""
+                    }
+                  },
+                  {
+                    "typ": "sps",
+                    "not": "",
+                    "Coadress": "c/o Trygghetsboendet Syrenen",
+                    "Gatabox": "Storgatan 25",
+                    "Postnr": "12321",
+                    "Postort": "JÖNKÖPING"
+                  }
+                ]
+              }
+            }
+          }
+        ]
+      }
+    }
+  },
+  "Särskild postadress utländsk": {
+    "Svar": {
+      "ec": "OK",
+      "Produkt": {
+        "id": "BFbokf",
+        "ver": "1.4"
+      },
+      "Process": {
+        "prddebug": "0",
+        "debug": "0",
+        "trace": "1"
+      },
+      "Objektlista": {
+        "antal": "1",
+        "Objekt": [
+          {
+            "Omfragad": {
+              "id": "5204312242",
+              "sekel": "19",
+              "not": "",
+              "Namnlista": {
+                "Namn": {
+                  "tilltal": "",
+                  "_t": "Gryning, Charlotta Lovisa"
+                },
+                "Mellannamn": "Lovisa",
+                "Efternamn": "Gryning",
+                "Fornamn": "Charlotta"
+              },
+              "Adresslista": {
+                "Adress": [
+                  {
+                    "typ": "fbf",
+                    "not": "",
+                    "Gatabox": "Bajonettstigen 1",
+                    "Postnr": "24001",
+                    "Postort": "LUND",
+                    "Lan": {
+                      "kod": "12",
+                      "_t": "Skåne län"
+                    },
+                    "Kommun": {
+                      "kod": "81",
+                      "_t": "Lund"
+                    },
+                    "Forsamling": {
+                      "kod": "05",
+                      "_t": "Norra Nöbbelöv"
+                    },
+                    "Landsdel": {
+                      "kod": ""
+                    },
+                    "Landskap": {
+                      "kod": ""
+                    },
+                    "Distrikt": {
+                      "kod": ""
+                    }
+                  },
+                  {
+                    "typ": "spu",
+                    "not": "",
+                    "Coadress": "C/o Ilona M. Engellau",
+                    "Fortsadress": "12 Ave. Albert 1 Er L' Hermitage",
+                    "Gatabox": "05801 Beaulieu S/m",
+                    "Land": "Frankrike"
+                  }
+                ]
+              }
+            }
+          }
+        ]
+      }
+    }
+  },
+  "Folkbokföringsadress saknas": {
+    "Svar": {
+      "ec": "OK",
+      "Produkt": {
+        "id": "BFbokf",
+        "ver": "1.4"
+      },
+      "Process": {
+        "prddebug": "0",
+        "debug": "0",
+        "trace": "1"
+      },
+      "Objektlista": {
+        "antal": "1",
+        "Objekt": [
+          {
+            "Omfragad": {
+              "id": "6909313337",
+              "sekel": "19",
+              "not": "",
+              "Namnlista": {
+                "Namn": {
+                  "tilltal": "",
+                  "_t": "Rasmusson, Ludvig Uno"
+                },
+                "Mellannamn": "Uno",
+                "Efternamn": "Rasmusson",
+                "Fornamn": "Ludvig"
+              },
+              "Adresslista": {
+                "Adress": [
+                  {
+                    "typ": "fbf",
+                    "not": "Folkbokföringsadress saknas",
+                    "Landsdel": {
+                      "kod": ""
+                    },
+                    "Landskap": {
+                      "kod": ""
+                    },
+                    "Distrikt": {
+                      "kod": ""
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        ]
+      }
+    }
+  },
+  "Utvandrad": {
+    "Svar": {
+      "ec": "OK",
+      "Produkt": {
+        "id": "BFbokf",
+        "ver": "1.4"
+      },
+      "Process": {
+        "prddebug": "0",
+        "debug": "0",
+        "trace": "1"
+      },
+      "Objektlista": {
+        "antal": "1",
+        "Objekt": [
+          {
+            "Omfragad": {
+              "id": "7606310006",
+              "sekel": "19",
+              "not": "Utvandrad eller avregistrerad av annat skäl",
+              "Namnlista": {
+                "Namn": {
+                  "tilltal": "",
+                  "_t": "Kehmal, Anjou"
+                },
+                "Mellannamn": {},
+                "Efternamn": "Kehmal",
+                "Fornamn": "Anjou"
+              },
+              "Adresslista": {
+                "Adress": [
+                  {
+                    "typ": "fbf",
+                    "not": "Senast kända folkbokföringsuppgifter:",
+                    "Coadress": "c/o Lafi",
+                    "Gatabox": "Karl Hovbergsgatan 39 B lgh 1002",
+                    "Postnr": "40110",
+                    "Postort": "Eskilstuna",
+                    "Landsdel": {
+                      "kod": ""
+                    },
+                    "Landskap": {
+                      "kod": ""
+                    },
+                    "Distrikt": {
+                      "kod": ""
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        ]
+      }
+    }
+  },
+  "Skyddad personuppgift": {
+    "Svar": {
+      "ec": "OK",
+      "Produkt": {
+        "id": "BFbokf",
+        "ver": "1.4"
+      },
+      "Process": {
+        "prddebug": "0",
+        "debug": "0",
+        "trace": "1"
+      },
+      "Objektlista": {
+        "antal": "1",
+        "Objekt": [
+          {
+            "Omfragad": {
+              "id": "7711317771",
+              "sekel": "19",
+              "not": "Personen har skyddade personuppgifter",
+              "Namnlista": {
+                "Namn": {
+                  "tilltal": "",
+                  "_t": "Personuppgift skyddad"
+                },
+                "Mellannamn": {},
+                "Efternamn": {},
+                "Fornamn": {}
+              },
+              "Adresslista": {
+                "Adress": [
+                  {
+                    "typ": "fbf",
+                    "not": "",
+                    "Gatabox": "Åter avsändaren",
+                    "Landsdel": {
+                      "kod": ""
+                    },
+                    "Landskap": {
+                      "kod": ""
+                    },
+                    "Distrikt": {
+                      "kod": ""
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        ]
+      }
+    }
+  },
+  "Personnummerbyte (nytt nummer)": {
+    "Svar": {
+      "ec": "OK",
+      "Produkt": {
+        "id": "BFbokf",
+        "ver": "1.4"
+      },
+      "Process": {
+        "prddebug": "0",
+        "debug": "0",
+        "trace": "1"
+      },
+      "Objektlista": {
+        "antal": "1",
+        "Objekt": [
+          {
+            "Omfragad": {
+              "id": "9202301124",
+              "sekel": "19",
+              "not": "Personnummerbyte. Gammalt nummer: 920230-2320",
+              "Namnlista": {
+                "Namn": {
+                  "tilltal": "",
+                  "_t": "Kropp, Eva Mia Syster"
+                },
+                "Mellannamn": "Mia",
+                "Efternamn": "Kropp",
+                "Fornamn": "Eva"
+              },
+              "Adresslista": {
+                "Adress": [
+                  {
+                    "typ": "fbf",
+                    "not": "",
+                    "Gatabox": "Sandgatan 1",
+                    "Postnr": "35212",
+                    "Postort": "JÖNKÖPING",
+                    "Lan": {
+                      "kod": "06",
+                      "_t": "Jönköpings län"
+                    },
+                    "Kommun": {
+                      "kod": "80",
+                      "_t": "Jönköping"
+                    },
+                    "Forsamling": {
+                      "kod": "02",
+                      "_t": "Jönköpings Kristina-Ljungarum"
+                    },
+                    "Landsdel": {
+                      "kod": ""
+                    },
+                    "Landskap": {
+                      "kod": ""
+                    },
+                    "Distrikt": {
+                      "kod": ""
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        ]
+      }
+    }
+  },
+  "Personnummerbyte(gammalt nummer)": {
+    "Svar": {
+      "ec": "OK",
+      "Produkt": {
+        "id": "BFbokf",
+        "ver": "1.4"
+      },
+      "Process": {
+        "prddebug": "0",
+        "debug": "0",
+        "trace": "1"
+      },
+      "Objektlista": {
+        "antal": "1",
+        "Objekt": [
+          {
+            "Omfragad": {
+              "id": "9202301124",
+              "sekel": "19",
+              "not": "Personnummerbyte. Gammalt nummer: 920230-2320",
+              "Namnlista": {
+                "Namn": {
+                  "tilltal": "",
+                  "_t": "Kropp, Eva Mia Syster"
+                },
+                "Mellannamn": "Mia",
+                "Efternamn": "Kropp",
+                "Fornamn": "Eva"
+              },
+              "Adresslista": {
+                "Adress": [
+                  {
+                    "typ": "fbf",
+                    "not": "",
+                    "Gatabox": "Sandgatan 1",
+                    "Postnr": "35212",
+                    "Postort": "JÖNKÖPING",
+                    "Lan": {
+                      "kod": "06",
+                      "_t": "Jönköpings län"
+                    },
+                    "Kommun": {
+                      "kod": "80",
+                      "_t": "Jönköping"
+                    },
+                    "Forsamling": {
+                      "kod": "02",
+                      "_t": "Jönköpings Kristina-Ljungarum"
+                    },
+                    "Landsdel": {
+                      "kod": ""
+                    },
+                    "Landskap": {
+                      "kod": ""
+                    },
+                    "Distrikt": {
+                      "kod": ""
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        ]
+      }
+    }
+  },
+  "Särskild postadress svensk": {
+    "Svar": {
+      "ec": "OK",
+      "Produkt": {
+        "id": "BFbokf",
+        "ver": "1.4"
+      },
+      "Process": {
+        "prddebug": "0",
+        "debug": "0",
+        "trace": "1"
+      },
+      "Objektlista": {
+        "antal": "1",
+        "Objekt": [
+          {
+            "Omfragad": {
+              "id": "9802308883",
+              "sekel": "19",
+              "not": "",
+              "Namnlista": {
+                "Namn": {
+                  "tilltal": "",
+                  "_t": "Vilde, Selma Tilde"
+                },
+                "Mellannamn": "Selma",
+                "Efternamn": "Vilde",
+                "Fornamn": "Tilde"
+              },
+              "Adresslista": {
+                "Adress": [
+                  {
+                    "typ": "fbf",
+                    "not": "",
+                    "Gatabox": "Husqvarnagatan 1 lgh 1005",
+                    "Postnr": "12345",
+                    "Postort": "JÖNKÖPING",
+                    "Lan": {
+                      "kod": "06",
+                      "_t": "Jönköpings län"
+                    },
+                    "Kommun": {
+                      "kod": "80",
+                      "_t": "Jönköping"
+                    },
+                    "Forsamling": {
+                      "kod": "02",
+                      "_t": "Jönköpings Kristina-Ljungarum"
+                    },
+                    "Landsdel": {
+                      "kod": ""
+                    },
+                    "Landskap": {
+                      "kod": ""
+                    },
+                    "Distrikt": {
+                      "kod": ""
+                    }
+                  },
+                  {
+                    "typ": "sps",
+                    "not": "",
+                    "Gatabox": "Kattsundsgatan 25 lgh 1001",
+                    "Postnr": "22501",
+                    "Postort": "MALMÖ"
+                  }
+                ]
+              }
+            }
+          }
+        ]
+      }
+    }
+  },
+  "Real Person": {
+    "Svar": {
+      "ec": "OK",
+      "Produkt": {
+        "id": "BFbokf",
+        "ver": "1.4"
+      },
+      "Process": {
+        "prddebug": "0",
+        "debug": "0",
+        "trace": "0"
+      },
+      "Objektlista": {
+        "antal": "1",
+        "Objekt": [
+          {
+            "Omfragad": {
+              "id": "8507099805",
+              "sekel": "19",
+              "not": "",
+              "fbfdatum": "20140417",
+              "Namnlista": {
+                "Namn": {
+                  "tilltal": "",
+                  "_t": "LastName, FirstName"
+                },
+                "Mellannamn": {},
+                "Efternamn": "LastName",
+                "Fornamn": "FirstName"
+              },
+              "Adresslista": {
+                "Adress": [
+                  {
+                    "typ": "fbf",
+                    "not": "",
+                    "Gatabox": "Sveavägen 12",
+                    "Postnr": "11312",
+                    "Postort": "Stockholm",
+                    "Lan": {
+                      "kod": "01",
+                      "_t": "Stockholms län"
+                    },
+                    "Kommun": {
+                      "kod": "80",
+                      "_t": "Stockholm"
+                    },
+                    "Forsamling": {
+                      "kod": "15",
+                      "_t": "Katarina"
+                    },
+                    "Landsdel": {
+                      "kod": ""
+                    },
+                    "Landskap": {
+                      "kod": ""
+                    },
+                    "Distrikt": {
+                      "kod": ""
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        ]
+      }
+    }
+  },
+  "Error": {
+    "Svar": {
+      "ec": "E ",
+      "Produkt": {
+        "id": "BFbokf",
+        "ver": "1.4"
+      },
+      "Process": {
+        "prddebug": "0",
+        "debug": "0",
+        "trace": "0"
+      },
+      "Objektlista": {
+        "antal": "1"
+      },
+      "Error": {
+        "Msg": [
+          {
+            "id": "XML8001",
+            "sev": "E",
+            "runid": "1",
+            "_t": "XML internal error:  Error \"E\" severity prohibited xml output for runid: 1"
+          },
+          {
+            "id": "STD0001",
+            "sev": "E",
+            "runid": "1",
+            "_t": "Det finns ingen person folkbokförd i Sverige, 16 år eller äldre, med personnummer 220230-2226"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/src/adapters/syna/index.ts
+++ b/src/adapters/syna/index.ts
@@ -36,6 +36,40 @@ export const getSynaBatches = async (
   return arrObjekt
 }
 
+const findException = (
+  omfragad: syna.Omfragad
+): PopulationRegistrationInformation['exception'] => {
+  let exception = null
+
+  const hasNot = omfragad.not !== ''
+  const address = omfragad.Adresslista.Adress.find((a) => a.typ === 'fbf')
+  const hasSpecialAddressAbroad = omfragad.Adresslista.Adress.some(
+    (a) => a.typ === 'spu'
+  )
+  const hasSpecialAddress = omfragad.Adresslista.Adress.some(
+    (a) => a.typ === 'sps'
+  )
+  const hasRegistrationMissing = address && address.not !== ''
+
+  if (hasSpecialAddress) {
+    exception = 'Särskild postadress svensk'
+  }
+
+  if (hasSpecialAddressAbroad) {
+    exception = 'Särskild postadress utländsk'
+  }
+
+  if (hasRegistrationMissing) {
+    exception = 'Folkbokföringsadress saknas'
+  }
+
+  if (hasNot) {
+    exception = omfragad.not
+  }
+
+  return exception
+}
+
 const toPopulationRegistrationInformation = (
   omfragad: syna.Omfragad
 ): PopulationRegistrationInformation => {
@@ -46,10 +80,13 @@ const toPopulationRegistrationInformation = (
     adrString = address.Gatabox
   }
 
+  const exception = findException(omfragad)
+
   const pri: PopulationRegistrationInformation = {
     pnr: omfragad.id,
     name: omfragad.Namnlista.Namn._t,
     address: adrString,
+    exception,
   }
 
   return pri

--- a/src/helpers/populationRegistration.ts
+++ b/src/helpers/populationRegistration.ts
@@ -27,7 +27,7 @@ export const areAddressesEqual = (
 ): boolean => {
   //Normalize addresses for comparison
   let contractAddress = normalize(contract.address)
-  let priAddress = normalize(pri.address)
+  let priAddress = pri.address ? normalize(pri.address) : pri.address
 
   return contractAddress === priAddress
 }

--- a/src/routes/contracts.ts
+++ b/src/routes/contracts.ts
@@ -29,7 +29,17 @@ export const getContract = async (
 ) => {
   try {
     const { id } = req.params
-    const [contract] = await db('contracts').select('*').where('id', id)
+    const [contract] = await db('contracts')
+      .select(
+        'contracts.*',
+        'population_registration_sync_exceptions.note as exception'
+      )
+      .leftJoin(
+        'population_registration_sync_exceptions',
+        'contracts.id',
+        'population_registration_sync_exceptions.contract_id'
+      )
+      .where('contracts.id', id)
     return res.send({ data: contract })
   } catch (error) {
     logger.error(error)

--- a/src/services/__tests__/populationInformationSync.spec.ts
+++ b/src/services/__tests__/populationInformationSync.spec.ts
@@ -243,7 +243,6 @@ describe('#syncSelection', () => {
     const selection_id = '76c179bb-7db2-4dc3-a6bb-199a82e128b9'
     const contract_information = { pnr, address: 'an address' }
     const population_registration_information = {
-      address: 'pri address',
       pnr: '191212121212',
       exception: 'Särskild postadress utländsk',
     }
@@ -271,7 +270,6 @@ describe('#syncSelection', () => {
     const selection_id = '76c179bb-7db2-4dc3-a6bb-199a82e128b9'
     const contract_information = { pnr, address: 'an address' }
     const population_registration_information = {
-      address: 'pri address',
       pnr: '191212121212',
       exception: null,
     }

--- a/src/services/__tests__/populationInformationSync.spec.ts
+++ b/src/services/__tests__/populationInformationSync.spec.ts
@@ -1,4 +1,5 @@
-import { getInformation } from '@app/adapters/creditsafe'
+import { getInformation as getInformationCreditsafe } from '@app/adapters/creditsafe'
+import { getInformation as getInformationSyna } from '@app/adapters/syna'
 import {
   getAutomatedStatus,
   isStatusOverrideable,
@@ -18,6 +19,7 @@ import { syncSelection } from '../populationInformationSync'
 import { db } from '@app/adapters/postgres'
 
 jest.mock('@app/services/db')
+jest.mock('@app/adapters/syna')
 jest.mock('@app/adapters/creditsafe')
 jest.mock('@app/helpers/populationRegistration')
 jest.mock('moment', () => () => ({ toDate: () => 'a mocked date' }))
@@ -30,7 +32,8 @@ describe('#syncSelection', () => {
         contract_information: { pnr: 'test pnr' },
       },
     ])
-    ;(getInformation as jest.Mock).mockResolvedValue([])
+    ;(getInformationCreditsafe as jest.Mock).mockResolvedValue([])
+    ;(getInformationSyna as jest.Mock).mockResolvedValue([])
     ;(saveContract as jest.Mock).mockResolvedValue({})
     ;(logSyncFailure as jest.Mock).mockResolvedValue({})
     ;(logSyncSuccess as jest.Mock).mockResolvedValue({})
@@ -51,7 +54,7 @@ describe('#syncSelection', () => {
     ])
 
     await syncSelection('id', 'user')
-    expect(getInformation).toHaveBeenCalledWith(['191212121212'])
+    expect(getInformationSyna).toHaveBeenCalledWith(['191212121212'])
   })
 
   test('it matches pnr and saves contract with info from population registration', async () => {
@@ -66,7 +69,7 @@ describe('#syncSelection', () => {
     ;(getContractsForSelection as jest.Mock).mockResolvedValue([
       { contract_information, status: 'CAN BE OVERRIDDEN' },
     ])
-    ;(getInformation as jest.Mock).mockResolvedValue([
+    ;(getInformationSyna as jest.Mock).mockResolvedValue([
       population_registration_information,
     ])
 
@@ -91,7 +94,7 @@ describe('#syncSelection', () => {
     ;(getContractsForSelection as jest.Mock).mockResolvedValue([
       { contract_information, status: 'CAN BE OVERRIDDEN' },
     ])
-    ;(getInformation as jest.Mock).mockResolvedValue([
+    ;(getInformationSyna as jest.Mock).mockResolvedValue([
       population_registration_information,
     ])
 
@@ -116,7 +119,7 @@ describe('#syncSelection', () => {
     ;(getContractsForSelection as jest.Mock).mockResolvedValue([
       { contract_information, status: 'NOT OVERRIDEABLE' },
     ])
-    ;(getInformation as jest.Mock).mockResolvedValue([
+    ;(getInformationSyna as jest.Mock).mockResolvedValue([
       population_registration_information,
     ])
 
@@ -141,7 +144,7 @@ describe('#syncSelection', () => {
     ;(getContractsForSelection as jest.Mock).mockResolvedValue([
       { contract_information, status: 'OVERRIDABLE' },
     ])
-    ;(getInformation as jest.Mock).mockResolvedValue([
+    ;(getInformationSyna as jest.Mock).mockResolvedValue([
       population_registration_information,
     ])
 
@@ -155,7 +158,7 @@ describe('#syncSelection', () => {
   })
 
   test('it logs success', async () => {
-    ;(getInformation as jest.Mock).mockResolvedValue([])
+    ;(getInformationSyna as jest.Mock).mockResolvedValue([])
 
     await syncSelection('id', 'user')
     expect(logSyncSuccess).toHaveBeenCalledWith('id', 'user')
@@ -163,7 +166,7 @@ describe('#syncSelection', () => {
   })
 
   test('it logs failure when something fails and throws error', async () => {
-    ;(getInformation as jest.Mock).mockImplementation(() => {
+    ;(getInformationSyna as jest.Mock).mockImplementation(() => {
       throw new Error('test')
     })
 
@@ -187,7 +190,7 @@ describe('#syncSelection', () => {
     ;(getContractsForSelection as jest.Mock).mockResolvedValue([
       { contract_information, status: 'CAN BE OVERRIDDEN' },
     ])
-    ;(getInformation as jest.Mock).mockResolvedValue([
+    ;(getInformationSyna as jest.Mock).mockResolvedValue([
       population_registration_information,
     ])
 
@@ -208,7 +211,7 @@ describe('#syncSelection', () => {
     ;(getContractsForSelection as jest.Mock).mockResolvedValue([
       { contract_information, status: 'CAN BE OVERRIDDEN' },
     ])
-    ;(getInformation as jest.Mock).mockResolvedValue([
+    ;(getInformationSyna as jest.Mock).mockResolvedValue([
       population_registration_information,
     ])
 
@@ -229,7 +232,7 @@ describe('#syncSelection', () => {
     ;(getContractsForSelection as jest.Mock).mockResolvedValue([
       { contract_information, id: '1339', status: 'CAN BE OVERRIDDEN' },
     ])
-    ;(getInformation as jest.Mock).mockResolvedValue([
+    ;(getInformationSyna as jest.Mock).mockResolvedValue([
       population_registration_information,
     ])
 
@@ -251,7 +254,7 @@ describe('#syncSelection', () => {
     ;(getContractsForSelection as jest.Mock).mockResolvedValue([
       { id: contract_id, contract_information, status: 'NOT OVERRIDEABLE' },
     ])
-    ;(getInformation as jest.Mock).mockResolvedValue([
+    ;(getInformationSyna as jest.Mock).mockResolvedValue([
       population_registration_information,
     ])
 
@@ -278,7 +281,7 @@ describe('#syncSelection', () => {
     ;(getContractsForSelection as jest.Mock).mockResolvedValue([
       { id: contract_id, contract_information, status: 'NOT OVERRIDEABLE' },
     ])
-    ;(getInformation as jest.Mock).mockResolvedValue([
+    ;(getInformationSyna as jest.Mock).mockResolvedValue([
       population_registration_information,
     ])
 

--- a/src/services/db.ts
+++ b/src/services/db.ts
@@ -84,12 +84,20 @@ export const getContractsForSelection = async (
   id: string
 ): Promise<Contract[]> => {
   return await db
-    .select('contracts.*')
+    .select(
+      'contracts.*',
+      'population_registration_sync_exceptions.note as exception'
+    )
     .from('contracts')
     .innerJoin(
       'selection_contracts',
       'contracts.id',
       'selection_contracts.contract_id'
+    )
+    .leftJoin(
+      'population_registration_sync_exceptions',
+      'contracts.id',
+      'population_registration_sync_exceptions.contract_id'
     )
     .where('selection_contracts.selection_id', id)
 }

--- a/src/services/db.ts
+++ b/src/services/db.ts
@@ -165,3 +165,25 @@ export const addContractToSelection = async (
     return
   }
 }
+
+export const addContractSyncException = async (
+  selectionId: string,
+  contractId: string,
+  note: string
+) => {
+  const existingException = await db('population_registration_sync_exceptions')
+    .where({
+      selection_id: selectionId,
+      contract_id: contractId,
+    })
+    .first()
+
+  if (!existingException) {
+    return db('population_registration_sync_exceptions').insert({
+      selection_id: selectionId,
+      contract_id: contractId,
+      note,
+    })
+  }
+  return
+}

--- a/src/services/populationInformationSync.ts
+++ b/src/services/populationInformationSync.ts
@@ -73,10 +73,7 @@ export const syncSelection = async (
         }
 
         const isValid = areAddressesEqual(c.contract_information, pri)
-        if (
-          ((!!pri.exception || isValid) && automaticDeletion) ||
-          personGotSecretIdentity
-        ) {
+        if ((isValid && automaticDeletion) || personGotSecretIdentity) {
           await deleteContractById(c.id, selectionId)
         } else {
           //save contract

--- a/src/services/populationInformationSync.ts
+++ b/src/services/populationInformationSync.ts
@@ -59,18 +59,24 @@ export const syncSelection = async (
         const pri = info.find(
           (i) => format(i.pnr) === format(c.contract_information.pnr)
         )
-
         if (!pri) {
           return
         }
 
-        if (!!pri.exception) {
+        const personGotSecretIdentity = [
+          'Personen har skyddade personuppgifter',
+          'Skyddad',
+        ].includes(pri?.exception as string)
+
+        if (!!pri.exception && !personGotSecretIdentity) {
           await addContractSyncException(selectionId, c.id, pri.exception)
         }
 
         const isValid = areAddressesEqual(c.contract_information, pri)
-
-        if ((!!pri.exception || isValid) && automaticDeletion) {
+        if (
+          ((!!pri.exception || isValid) && automaticDeletion) ||
+          personGotSecretIdentity
+        ) {
           await deleteContractById(c.id, selectionId)
         } else {
           //save contract

--- a/src/services/populationInformationSync.ts
+++ b/src/services/populationInformationSync.ts
@@ -41,7 +41,7 @@ const getPopulationRegistrationInformation = async (
 export const syncSelection = async (
   selectionId: string,
   user: string,
-  onlyInvalid = false
+  automaticDeletion = false
 ) => {
   try {
     const allContracts = await getContractsForSelection(selectionId)
@@ -70,7 +70,7 @@ export const syncSelection = async (
 
         const isValid = areAddressesEqual(c.contract_information, pri)
 
-        if (isValid && onlyInvalid) {
+        if ((!!pri.exception || isValid) && automaticDeletion) {
           await deleteContractById(c.id, selectionId)
         } else {
           //save contract

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,7 +5,6 @@ export enum ContractStatus {
   MANUALLY_VERIFIED = 'MANUALLY_VERIFIED',
   UNDER_INVESTIGATION = 'UNDER_INVESTIGATION',
 }
-
 export interface ContractInformation {
   pnr: string
   name: string
@@ -16,6 +15,7 @@ export interface PopulationRegistrationInformation {
   pnr: string
   name: string
   address: string
+  exception: null | string
 }
 
 export interface Contract {

--- a/src/types.ts
+++ b/src/types.ts
@@ -24,6 +24,7 @@ export interface Contract {
   population_registration_information?: PopulationRegistrationInformation
   status?: ContractStatus
   comment?: string
+  exception?: string
   last_population_registration_lookup: Date | null
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -13,8 +13,8 @@ export interface ContractInformation {
 
 export interface PopulationRegistrationInformation {
   pnr: string
-  name: string
-  address: string
+  name?: string
+  address?: string
   exception: null | string
 }
 


### PR DESCRIPTION
- handle exceptions from Syna and Creditsafe
- exceptions are returned to the `syncSelection` where we store them in the DB and delete the contracts that have exceptions